### PR TITLE
Fixed typos in readme and examplePDFA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ typings/
 
 # pdf
 test.pdf
+testPDFA.pdf

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ npm install @alheimsins/pdf-make
 })()
 ```
 
-### PDF A2
+### PDF/A-2B
 
 ```js
 (async () => {
@@ -55,8 +55,8 @@ $ npm install @alheimsins/pdf-make
     ]
   }
   const options = {
-    type: 'A',
-    version: '2'
+    type: '2',
+    version: 'B'
   }
 
   // Creates PDF buffer

--- a/examplePDFA.js
+++ b/examplePDFA.js
@@ -8,8 +8,8 @@
     ]
   }
   const options = {
-    type: 'A',
-    version: '2'
+    type: '2',
+    version: 'B'
   }
 
   // Creates PDF buffer


### PR DESCRIPTION
Trøtt feil i forrige PR, eksempelet ble ikke en gyldig pdf/a, siden man må spesifisere hvilken versjon av pdf/a man ønsker å bruke (enten 2b eller 3b)